### PR TITLE
Add styled HTML final report support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Follow the installation and running instructions above. This requires Python kno
 
 6. **Generate a Final Report**:
    - The AI Manager will synthesize all findings into a comprehensive report
-   - You can download the report as an HTML file
+   - A styled HTML version is created using a Jinja2 template
+   - You can download the Markdown or HTML report
 
 ## Project Structure
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -82,7 +82,8 @@ The AI Data Analysis Assistant is designed to guide you through a structured dat
    - Expand the "Provide feedback on the final report" section
    - Enter your feedback
    - Click "Send Feedback" to get a revised report
-4. You can download the report as an HTML file by clicking "Download Report as HTML"
+4. The app also renders a styled HTML report using a Jinja2 template.
+   Click "Download Styled HTML" to save it locally.
 
 ## Navigation
 

--- a/features/final_report.py
+++ b/features/final_report.py
@@ -7,8 +7,10 @@ from src.ui_helpers import (
     add_to_conversation,
     check_api_key,
     add_download_buttons,
-    format_results_markdown # Import necessary helpers
+    format_results_markdown,
+    format_results_html
 )
+from src.report_utils import render_final_report_html
 
 def display_final_report_step():
     """Displays the Final Report step."""
@@ -82,18 +84,26 @@ def display_final_report_step():
         except Exception as e:
             st.error(f"Error creating report download button: {e}")
 
-        # Optional: Convert Markdown to HTML for better preview or other formats?
+        # Styled HTML report using the Jinja2 template
         try:
-            html_report = markdown.markdown(st.session_state.final_report)
+            analysis_results_html = format_results_html(st.session_state.analysis_results)
+            html_report = render_final_report_html({
+                "project_name": st.session_state.project_name,
+                "problem_statement": st.session_state.problem_statement,
+                "manager_plan": st.session_state.manager_plan,
+                "analyst_summary": st.session_state.analyst_summary,
+                "analysis_results_html": analysis_results_html,
+            })
+            st.components.v1.html(html_report, height=600, scrolling=True)
             st.download_button(
-               label="Download Report (HTML)",
-               data=html_report,
-               file_name=f"{st.session_state.project_name}_Final_Report.html",
-               mime="text/html",
-               key="download_report_html"
-               )
+                label="Download Styled HTML",
+                data=html_report,
+                file_name=f"{st.session_state.project_name}_Final_Report.html",
+                mime="text/html",
+                key="download_report_html"
+            )
         except Exception as e:
-            st.warning(f"Could not generate HTML download: {e}")
+            st.warning(f"Could not generate styled HTML: {e}")
 
 
     add_download_buttons("FinalReport")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ python-dotenv>=1.0.0
 
 # Report Generation/Downloads
 markdown>=3.5
+jinja2>=3.0
 openpyxl>=3.1.0 # Reading/Writing Excel files (.xlsx)
 
 # Document Processing

--- a/src/report_utils.py
+++ b/src/report_utils.py
@@ -1,0 +1,10 @@
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+
+def render_final_report_html(data: dict) -> str:
+    """Render the final report HTML using the Jinja2 template."""
+    template_dir = Path(__file__).resolve().parent.parent / "templates"
+    env = Environment(loader=FileSystemLoader(template_dir))
+    template = env.get_template("final_report_template.html")
+    return template.render(**data)

--- a/src/ui_helpers.py
+++ b/src/ui_helpers.py
@@ -265,6 +265,21 @@ def format_results_markdown(analysis_results):
 
     return markdown_output
 
+def format_results_html(analysis_results):
+    """Convert analysis results list into styled HTML."""
+    if not analysis_results:
+        return "<p>No analysis results available.</p>"
+
+    html_output = ""
+    for i, result in enumerate(analysis_results):
+        html_output += f"<h3>Task {i+1}: {result.get('task', 'N/A')}</h3>"
+        html_output += f"<p><strong>Approach:</strong> {result.get('approach', 'N/A')}</p>"
+        code_block = result.get('code', 'N/A')
+        html_output += f"<pre><code>{code_block}</code></pre>"
+        html_output += f"<p><strong>Results:</strong> {result.get('results_text', 'N/A')}</p>"
+        html_output += f"<p><strong>Insights:</strong> {result.get('insights', 'N/A')}</p>"
+    return html_output
+
 # Function to check API key before AI calls
 def check_api_key():
     if not st.session_state.gemini_api_key:

--- a/templates/final_report_template.html
+++ b/templates/final_report_template.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        h1, h2, h3 { color: #2c3e50; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+        pre { background-color: #f8f8f8; padding: 10px; overflow-x: auto; }
+        code { font-family: monospace; }
+    </style>
+</head>
+<body>
+    <h1>{{ project_name }}</h1>
+    <h2>Problem Statement</h2>
+    <p>{{ problem_statement }}</p>
+
+    <h2>Manager Plan</h2>
+    {{ manager_plan | safe }}
+
+    <h2>Analyst Summary</h2>
+    {{ analyst_summary | safe }}
+
+    <h2>Analysis Results</h2>
+    {{ analysis_results_html | safe }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add jinja2 dependency
- implement `render_final_report_html` and new HTML template
- support HTML formatting for analysis results
- display styled report in Final Report step and allow download
- document new HTML report in README and user guide

## Testing
- `python -m py_compile src/report_utils.py src/ui_helpers.py features/final_report.py`